### PR TITLE
Add unit tests for transaction and antifraud modules

### DIFF
--- a/challenge.sln
+++ b/challenge.sln
@@ -17,8 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "antifraud-application", "an
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "antifraud-infrastructure", "antifraud-infrastructure\antifraud-infrastructure.csproj", "{1D3963C9-9286-46A8-84A6-B4C75494BBC6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "challenge.tests", "challenge.tests\challenge.tests.csproj", "{3CD5AB93-518D-4833-93A5-D26BA8F7F79C}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
@@ -49,9 +51,13 @@ Global
 		{B2A40635-3169-4CDC-A0C8-D89F04DC3959}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1D3963C9-9286-46A8-84A6-B4C75494BBC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1D3963C9-9286-46A8-84A6-B4C75494BBC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1D3963C9-9286-46A8-84A6-B4C75494BBC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1D3963C9-9286-46A8-84A6-B4C75494BBC6}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {1D3963C9-9286-46A8-84A6-B4C75494BBC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1D3963C9-9286-46A8-84A6-B4C75494BBC6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3CD5AB93-518D-4833-93A5-D26BA8F7F79C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3CD5AB93-518D-4833-93A5-D26BA8F7F79C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3CD5AB93-518D-4833-93A5-D26BA8F7F79C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3CD5AB93-518D-4833-93A5-D26BA8F7F79C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/challenge.tests/ApplyAntifraudDecisionHandlerTests.cs
+++ b/challenge.tests/ApplyAntifraudDecisionHandlerTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using transaction_domain.Core.Sqs;
+using transaction_domain.Core.TransactionModule.Entities;
+using transaction_domain.Core.TransactionModule.Enums;
+using transaction_domain.Core.TransactionModule.Interfaces;
+using antifraud_application.Commands.ApplyAntifraudDecision;
+
+namespace challenge.tests;
+
+public class ApplyAntifraudDecisionHandlerTests
+{
+    [Fact]
+    public async Task Handle_ValueGreaterThan2000_Rejects()
+    {
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 3000m);
+        var cts = new CancellationTokenSource();
+
+        var consumer = new Mock<IKafkaConsumer>();
+        consumer.Setup(c => c.Configure());
+        consumer.Setup(c => c.ReadMessage(It.IsAny<CancellationToken>())).Returns(transaction.Id.ToString());
+
+        var repository = new Mock<ITransactionAntiFraudRepository>();
+        repository.Setup(r => r.GetTransactionById(transaction.Id, It.IsAny<CancellationToken>())).ReturnsAsync(transaction);
+        repository.Setup(r => r.TotalAmountAtDate(transaction.SourceAccountId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(0m);
+        repository.Setup(r => r.UpdateStatus(transaction.Id, TransactionStatusEnum.REJECTED, It.IsAny<CancellationToken>()))
+                  .Callback(() => cts.Cancel())
+                  .ReturnsAsync(transaction);
+
+        var handler = new ApplyAntifraudDecisionHandler(Mock.Of<ILogger<ApplyAntifraudDecisionHandler>>(), repository.Object, consumer.Object);
+
+        var result = await handler.Handle(new ApplyAntifraudDecisionCommand(cts.Token), cts.Token);
+
+        Assert.True(result.Success);
+        repository.Verify(r => r.UpdateStatus(transaction.Id, TransactionStatusEnum.REJECTED, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AccumulatedAmountGreaterThan20000_Rejects()
+    {
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+        var cts = new CancellationTokenSource();
+
+        var consumer = new Mock<IKafkaConsumer>();
+        consumer.Setup(c => c.Configure());
+        consumer.Setup(c => c.ReadMessage(It.IsAny<CancellationToken>())).Returns(transaction.Id.ToString());
+
+        var repository = new Mock<ITransactionAntiFraudRepository>();
+        repository.Setup(r => r.GetTransactionById(transaction.Id, It.IsAny<CancellationToken>())).ReturnsAsync(transaction);
+        repository.Setup(r => r.TotalAmountAtDate(transaction.SourceAccountId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(25000m);
+        repository.Setup(r => r.UpdateStatus(transaction.Id, TransactionStatusEnum.REJECTED, It.IsAny<CancellationToken>()))
+                  .Callback(() => cts.Cancel())
+                  .ReturnsAsync(transaction);
+
+        var handler = new ApplyAntifraudDecisionHandler(Mock.Of<ILogger<ApplyAntifraudDecisionHandler>>(), repository.Object, consumer.Object);
+
+        var result = await handler.Handle(new ApplyAntifraudDecisionCommand(cts.Token), cts.Token);
+
+        Assert.True(result.Success);
+        repository.Verify(r => r.UpdateStatus(transaction.Id, TransactionStatusEnum.REJECTED, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Default_Approves()
+    {
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+        var cts = new CancellationTokenSource();
+
+        var consumer = new Mock<IKafkaConsumer>();
+        consumer.Setup(c => c.Configure());
+        consumer.Setup(c => c.ReadMessage(It.IsAny<CancellationToken>())).Returns(transaction.Id.ToString());
+
+        var repository = new Mock<ITransactionAntiFraudRepository>();
+        repository.Setup(r => r.GetTransactionById(transaction.Id, It.IsAny<CancellationToken>())).ReturnsAsync(transaction);
+        repository.Setup(r => r.TotalAmountAtDate(transaction.SourceAccountId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(1000m);
+        repository.Setup(r => r.UpdateStatus(transaction.Id, TransactionStatusEnum.APPROVED, It.IsAny<CancellationToken>()))
+                  .Callback(() => cts.Cancel())
+                  .ReturnsAsync(transaction);
+
+        var handler = new ApplyAntifraudDecisionHandler(Mock.Of<ILogger<ApplyAntifraudDecisionHandler>>(), repository.Object, consumer.Object);
+
+        var result = await handler.Handle(new ApplyAntifraudDecisionCommand(cts.Token), cts.Token);
+
+        Assert.True(result.Success);
+        repository.Verify(r => r.UpdateStatus(transaction.Id, TransactionStatusEnum.APPROVED, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/challenge.tests/ApplyAntifraudDecisionHandlerTests.cs
+++ b/challenge.tests/ApplyAntifraudDecisionHandlerTests.cs
@@ -5,6 +5,7 @@ using transaction_domain.Core.TransactionModule.Entities;
 using transaction_domain.Core.TransactionModule.Enums;
 using transaction_domain.Core.TransactionModule.Interfaces;
 using antifraud_application.Commands.ApplyAntifraudDecision;
+using Xunit;
 
 namespace challenge.tests;
 

--- a/challenge.tests/CreateTransactionHandlerTests.cs
+++ b/challenge.tests/CreateTransactionHandlerTests.cs
@@ -3,6 +3,7 @@ using transaction_domain.Core.Sqs;
 using transaction_domain.Core.TransactionModule.Entities;
 using transaction_domain.Core.TransactionModule.Interfaces;
 using transaction_application.Commands.CreateTransaction;
+using Xunit;
 
 namespace challenge.tests;
 

--- a/challenge.tests/CreateTransactionHandlerTests.cs
+++ b/challenge.tests/CreateTransactionHandlerTests.cs
@@ -1,0 +1,32 @@
+using Moq;
+using transaction_domain.Core.Sqs;
+using transaction_domain.Core.TransactionModule.Entities;
+using transaction_domain.Core.TransactionModule.Interfaces;
+using transaction_application.Commands.CreateTransaction;
+
+namespace challenge.tests;
+
+public class CreateTransactionHandlerTests
+{
+    [Fact]
+    public async Task Handle_CreatesTransactionAndSendsMessage()
+    {
+        var repository = new Mock<ITransactionRepository>();
+        Transaction? saved = null;
+        repository.Setup(r => r.CreateTransaction(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
+                  .Callback<Transaction, CancellationToken>((t, _) => saved = t)
+                  .ReturnsAsync((Transaction t, CancellationToken _) => t);
+
+        var producer = new Mock<IKafkaProducer>();
+        var handler = new CreateTransactionHandler(repository.Object, producer.Object);
+
+        var command = new CreateTransactionCommand(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.NotNull(saved);
+        Assert.Equal(saved!.Id, result.TransactionExternalId);
+        Assert.Equal(saved.CreatedAt, result.CreatedAt);
+        producer.Verify(p => p.SendMessage(saved.Id.ToString(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/challenge.tests/GetTransactionHandlerTests.cs
+++ b/challenge.tests/GetTransactionHandlerTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using transaction_domain.Core.TransactionModule.Entities;
 using transaction_domain.Core.TransactionModule.Interfaces;
 using transaction_application.Queries.GetTransaction;
+using Xunit;
 
 namespace challenge.tests;
 

--- a/challenge.tests/GetTransactionHandlerTests.cs
+++ b/challenge.tests/GetTransactionHandlerTests.cs
@@ -1,0 +1,30 @@
+using Moq;
+using transaction_domain.Core.TransactionModule.Entities;
+using transaction_domain.Core.TransactionModule.Interfaces;
+using transaction_application.Queries.GetTransaction;
+
+namespace challenge.tests;
+
+public class GetTransactionHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsTransactionDto()
+    {
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+        var repository = new Mock<ITransactionRepository>();
+        repository.Setup(r => r.GetTransaction(transaction.Id, It.IsAny<CancellationToken>())).ReturnsAsync(transaction);
+
+        var handler = new GetTransactionHandler(repository.Object);
+        var query = new GetTransactionQuery(transaction.Id);
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        Assert.Equal(transaction.Id, result.TransactionExternalId);
+        Assert.Equal(transaction.SourceAccountId, result.SourceAccountId);
+        Assert.Equal(transaction.TargetAccountId, result.TargetAccountId);
+        Assert.Equal(transaction.TransferTypeId, result.TransferTypeId);
+        Assert.Equal(transaction.Value, result.Value);
+        Assert.Equal(transaction.Status, result.Status);
+        Assert.Equal(transaction.CreatedAt, result.CreatedAt);
+    }
+}

--- a/challenge.tests/TransactionAntiFraudRepositoryTests.cs
+++ b/challenge.tests/TransactionAntiFraudRepositoryTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using transaction_domain.Core.TransactionModule.Entities;
 using transaction_domain.Core.TransactionModule.Enums;
 using antifraud_infrastructure.Persistence;
+using Xunit;
 
 namespace challenge.tests;
 

--- a/challenge.tests/TransactionAntiFraudRepositoryTests.cs
+++ b/challenge.tests/TransactionAntiFraudRepositoryTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using transaction_domain.Core.TransactionModule.Entities;
+using transaction_domain.Core.TransactionModule.Enums;
+using antifraud_infrastructure.Persistence;
+
+namespace challenge.tests;
+
+public class TransactionAntiFraudRepositoryTests
+{
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static TransactionAntiFraudRepository CreateRepository(ApplicationDbContext context)
+    {
+        var logger = Mock.Of<ILogger<TransactionAntiFraudRepository>>();
+        return new TransactionAntiFraudRepository(context, logger);
+    }
+
+    [Fact]
+    public async Task GetTransactionById_ReturnsEntity()
+    {
+        using var context = CreateContext();
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+        context.Transactions.Add(transaction);
+        context.SaveChanges();
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetTransactionById(transaction.Id, CancellationToken.None);
+
+        Assert.Equal(transaction.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task UpdateStatus_ChangesStatus()
+    {
+        using var context = CreateContext();
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+        context.Transactions.Add(transaction);
+        context.SaveChanges();
+        var repository = CreateRepository(context);
+
+        var result = await repository.UpdateStatus(transaction.Id, TransactionStatusEnum.APPROVED, CancellationToken.None);
+
+        Assert.Equal(TransactionStatusEnum.APPROVED, result.Status);
+        Assert.Equal(TransactionStatusEnum.APPROVED, context.Transactions.Find(transaction.Id)!.Status);
+    }
+
+    [Fact]
+    public async Task UpdateStatus_NotFound_Throws()
+    {
+        using var context = CreateContext();
+        var repository = CreateRepository(context);
+
+        await Assert.ThrowsAsync<Exception>(() => repository.UpdateStatus(Guid.NewGuid(), TransactionStatusEnum.APPROVED, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task TotalAmountAtDate_SumsValuesSameDay()
+    {
+        using var context = CreateContext();
+        var sourceId = Guid.NewGuid();
+        var date = new DateTime(2024,1,1,10,0,0,DateTimeKind.Utc);
+        var t1 = new Transaction { Id = Guid.NewGuid(), SourceAccountId = sourceId, TargetAccountId = Guid.NewGuid(), TransferTypeId = 1, Value = 100m, Status = TransactionStatusEnum.PENDING, CreatedAt = date };
+        var t2 = new Transaction { Id = Guid.NewGuid(), SourceAccountId = sourceId, TargetAccountId = Guid.NewGuid(), TransferTypeId = 1, Value = 50m, Status = TransactionStatusEnum.PENDING, CreatedAt = date.AddHours(3) };
+        var t3 = new Transaction { Id = Guid.NewGuid(), SourceAccountId = sourceId, TargetAccountId = Guid.NewGuid(), TransferTypeId = 1, Value = 25m, Status = TransactionStatusEnum.PENDING, CreatedAt = date.AddDays(1) };
+        context.Transactions.AddRange(t1, t2, t3);
+        context.SaveChanges();
+        var repository = CreateRepository(context);
+
+        var result = await repository.TotalAmountAtDate(sourceId, date, CancellationToken.None);
+
+        Assert.Equal(150m, result);
+    }
+}

--- a/challenge.tests/TransactionRepositoryTests.cs
+++ b/challenge.tests/TransactionRepositoryTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using transaction_domain.Core.TransactionModule.Entities;
 using transaction_domain.Core.TransactionModule.Enums;
 using transaction_infrastructure.Persistence;
+using Xunit;
 
 namespace challenge.tests;
 

--- a/challenge.tests/TransactionRepositoryTests.cs
+++ b/challenge.tests/TransactionRepositoryTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using transaction_domain.Core.TransactionModule.Entities;
+using transaction_domain.Core.TransactionModule.Enums;
+using transaction_infrastructure.Persistence;
+
+namespace challenge.tests;
+
+public class TransactionRepositoryTests
+{
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static TransactionRepository CreateRepository(ApplicationDbContext context)
+    {
+        var logger = Mock.Of<ILogger<TransactionRepository>>();
+        return new TransactionRepository(context, logger);
+    }
+
+    [Fact]
+    public async Task CreateTransaction_PersistsEntity()
+    {
+        using var context = CreateContext();
+        var repository = CreateRepository(context);
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+
+        var result = await repository.CreateTransaction(transaction, CancellationToken.None);
+
+        Assert.Equal(transaction.Id, result.Id);
+        Assert.Single(context.Transactions);
+    }
+
+    [Fact]
+    public async Task GetTransaction_ReturnsEntity()
+    {
+        using var context = CreateContext();
+        var transaction = new Transaction(Guid.NewGuid(), Guid.NewGuid(), 1, 100m);
+        context.Transactions.Add(transaction);
+        context.SaveChanges();
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetTransaction(transaction.Id, CancellationToken.None);
+
+        Assert.Equal(transaction.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task GetTransaction_NotFound_Throws()
+    {
+        using var context = CreateContext();
+        var repository = CreateRepository(context);
+
+        await Assert.ThrowsAsync<Exception>(() => repository.GetTransaction(Guid.NewGuid(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task TotalAmountAtDate_ReturnsSum()
+    {
+        using var context = CreateContext();
+        var sourceId = Guid.NewGuid();
+        var date = DateTime.UtcNow;
+        var t1 = new Transaction { Id = Guid.NewGuid(), SourceAccountId = sourceId, TargetAccountId = Guid.NewGuid(), TransferTypeId = 1, Value = 100m, Status = TransactionStatusEnum.PENDING, CreatedAt = date };
+        var t2 = new Transaction { Id = Guid.NewGuid(), SourceAccountId = sourceId, TargetAccountId = Guid.NewGuid(), TransferTypeId = 1, Value = 50m, Status = TransactionStatusEnum.PENDING, CreatedAt = date };
+        var t3 = new Transaction { Id = Guid.NewGuid(), SourceAccountId = sourceId, TargetAccountId = Guid.NewGuid(), TransferTypeId = 1, Value = 25m, Status = TransactionStatusEnum.PENDING, CreatedAt = date.AddDays(1) };
+        context.Transactions.AddRange(t1, t2, t3);
+        context.SaveChanges();
+        var repository = CreateRepository(context);
+
+        var result = await repository.TotalAmountAtDate(sourceId, date, CancellationToken.None);
+
+        Assert.Equal(150m, result);
+    }
+}

--- a/challenge.tests/challenge.tests.csproj
+++ b/challenge.tests/challenge.tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\transaction-infrastructure\transaction-infrastructure.csproj" />
+    <ProjectReference Include="..\antifraud-infrastructure\antifraud-infrastructure.csproj" />
+    <ProjectReference Include="..\antifraud-application\antifraud-application.csproj" />
+    <ProjectReference Include="..\transaction-application\transaction-application.csproj" />
+    <ProjectReference Include="..\transaction-domain\transaction-domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/challenge.tests/challenge.tests.csproj
+++ b/challenge.tests/challenge.tests.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.9.0" />
@@ -12,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+	<PackageReference Include="Azure.Core" Version="1.38.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\transaction-infrastructure\transaction-infrastructure.csproj" />


### PR DESCRIPTION
## Summary
- add xUnit test project with references to application and infrastructure layers
- cover transaction repository behavior and antifraud repository operations
- exercise antifraud decision logic, transaction creation, and transaction retrieval handlers

## Testing
- `dotnet test challenge.tests/challenge.tests.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.19 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68b90132c58483338c4fba81a6a82679