### PR TITLE
Add containers for transaction and antifraud services

### DIFF
--- a/antifraud-worker/Dockerfile
+++ b/antifraud-worker/Dockerfile
@@ -2,7 +2,6 @@
 
 # Esta fase se usa cuando se ejecuta desde VS en modo rápido (valor predeterminado para la configuración de depuración)
 FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
-USER $APP_UID
 WORKDIR /app
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,3 +34,36 @@ services:
       - KAFKA_CLUSTERS_0_NAME=local-kafka
       - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:29092
       - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:2181
+
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=4N&XY&d_0y6+
+    ports:
+      - "1433:1433"
+
+  transaction-ms:
+    build:
+      context: .
+      dockerfile: transaction-ms/Dockerfile
+    depends_on:
+      - mssql
+      - kafka
+    environment:
+      ConnectionStrings__DefaultConnectionString: Server=mssql,1433;Database=transactionDb;User Id=sa;Password=4N&XY&d_0y6+;Encrypt=False;TrustServerCertificate=true
+      kafka__bootstrapServers: kafka:29092
+    ports:
+      - "8081:8080"
+
+  antifraud-worker:
+    build:
+      context: .
+      dockerfile: antifraud-worker/Dockerfile
+    depends_on:
+      - mssql
+      - kafka
+    environment:
+      ConnectionStrings__DefaultConnectionString: Server=mssql,1433;Database=transactionDb;User Id=sa;Password=4N&XY&d_0y6+;Encrypt=False;TrustServerCertificate=true
+      kafka__bootstrapServers: kafka:29092
+

--- a/transaction-ms/Dockerfile
+++ b/transaction-ms/Dockerfile
@@ -2,7 +2,6 @@
 
 # Esta fase se usa cuando se ejecuta desde VS en modo rápido (valor predeterminado para la configuración de depuración)
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081


### PR DESCRIPTION
## Summary
- add SQL Server, transaction-ms, and antifraud-worker services to docker-compose
- run apps as default container user by removing APP_UID from Dockerfiles

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b90831a67883339570f4a402724e80