### PR TITLE
Aplicar migraciones automáticamente al iniciar el contenedor

### DIFF
--- a/transaction-ms/Dockerfile
+++ b/transaction-ms/Dockerfile
@@ -26,4 +26,8 @@ RUN dotnet publish "./transaction-ms.csproj" -c $BUILD_CONFIGURATION -o /app/pub
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "transaction-ms.dll"]
+# Install dotnet-ef tool to run migrations at startup
+RUN dotnet tool install --global dotnet-ef
+ENV PATH="$PATH:/root/.dotnet/tools"
+# Apply migrations and start the service
+ENTRYPOINT ["bash", "-c", "dotnet ef database update && dotnet transaction-ms.dll"]


### PR DESCRIPTION
## Resumen
- Instala la herramienta `dotnet-ef` en la imagen final del servicio `transaction-ms`.
- Ejecuta `dotnet ef database update` antes de iniciar el servicio para aplicar migraciones automáticamente.

## Testing
- `apt-get update` *(falla: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*
- `dotnet test challenge.sln` *(falla: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b90c5313508333bf33d567018e6d06